### PR TITLE
remove the finalizer so policy deletes can happen without the running…

### DIFF
--- a/pkg/controller/grcpolicy/grcpolicy_controller.go
+++ b/pkg/controller/grcpolicy/grcpolicy_controller.go
@@ -3,6 +3,7 @@
 // Note to U.S. Government Users Restricted Rights:
 // Use, duplication or disclosure restricted by GSA ADP Schedule
 // Contract with IBM Corp.
+// Copyright (c) 2020 Red Hat, Inc.
 
 package grcpolicy
 


### PR DESCRIPTION
This is a candidate PR that will address a cluster detach scenario where the helm chart for the policy controller gets wiped sometimes before the policies are removed.  Removing the finalizer separates the cleanup dependency between the policy and the pod.

Fix for https://github.com/open-cluster-management/backlog/issues/1930