### PR TITLE
find out what users are in the cluster role bindings list

### DIFF
--- a/pkg/controller/grcpolicy/grcpolicy_controller.go
+++ b/pkg/controller/grcpolicy/grcpolicy_controller.go
@@ -306,6 +306,10 @@ func checkAllClusterLevel(clusterRoleBindingList *v1.ClusterRoleBindingList) (us
 			}
 		}
 	}
+	fmt.Println("Users with cluster-admin access bindings: ")
+	for k, v := range usersMap {
+		fmt.Printf("  user = %v; access = %v \n", k, v)
+	}
 	return len(usersMap)
 }
 


### PR DESCRIPTION
Looking at the system I count 6, but the controller seems to report 7 users.
We may want a way to debug this easier.