### PR TITLE
Set a minimum on maxClusterRoleBindingUsers

### DIFF
--- a/deploy/crds/policy.open-cluster-management.io_iampolicies_crd.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_iampolicies_crd.yaml
@@ -51,6 +51,7 @@ spec:
             maxClusterRoleBindingUsers:
               description: Maximum number of cluster role binding users still valid
                 before it is considered non-compliant
+              minimum: 1
               type: integer
             namespaceSelector:
               description: Selecting a list of namespaces where the policy applies

--- a/deploy/crds/v1/policy.open-cluster-management.io_iampolicies.yaml
+++ b/deploy/crds/v1/policy.open-cluster-management.io_iampolicies.yaml
@@ -51,6 +51,7 @@ spec:
               maxClusterRoleBindingUsers:
                 description: Maximum number of cluster role binding users still valid
                   before it is considered non-compliant
+                minimum: 1
                 type: integer
               namespaceSelector:
                 description: Selecting a list of namespaces where the policy applies

--- a/pkg/apis/policy/v1/iampolicy_types.go
+++ b/pkg/apis/policy/v1/iampolicy_types.go
@@ -59,6 +59,7 @@ type IamPolicySpec struct {
 	NamespaceSelector Target            `json:"namespaceSelector,omitempty"`
 	LabelSelector     map[string]string `json:"labelSelector,omitempty"`
 	// Maximum number of cluster role binding users still valid before it is considered non-compliant
+	// +kubebuilder:validation:Minimum=1
 	MaxClusterRoleBindingUsers int `json:"maxClusterRoleBindingUsers,omitempty"`
 	// Name of the cluster role  refefenced by the cluster role bindings,  defaults to "cluster-admin" if none specified
 	ClusterRole string `json:"clusterRole,omitempty"`


### PR DESCRIPTION
Since setting maxClusterRoleBindingUsers to 0 is an invalid situation,
this sets the minimum to 1.