### PR TITLE
Use utility package for logging

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
             - iam-policy-controller
           args:
             - "--enable-lease=true"
+            - "--log-level=2"
+            - "--v=0"
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -146,6 +146,8 @@ spec:
       containers:
       - args:
         - --enable-lease=true
+        - --log-level=2
+        - --v=0
         command:
         - iam-policy-controller
         env:

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/stolostron/iam-policy-controller
 go 1.17
 
 require (
+	github.com/go-logr/zapr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stolostron/go-log-utils v0.1.0
 	github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.3
@@ -29,7 +31,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -1127,6 +1127,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+github.com/stolostron/go-log-utils v0.1.0 h1:YRi84JogWKHCfrif46m/4rep+ucsc80c9667FzaBbTA=
+github.com/stolostron/go-log-utils v0.1.0/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
 github.com/stolostron/go-template-utils/v2 v2.2.2/go.mod h1:z4d9KZkkW5jAHns3bafVTmab+eq/jVsoFRYWbH37Qu4=
 github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38 h1:a3mDbBUE0eVXdzv0IIsz6/48F7Ru6LxwPduryJU7UXQ=
 github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38/go.mod h1:8lcjUP24z9gIZ1nCydZyOxIqz6CpVDtVt5KPAlsi+tY=

--- a/main.go
+++ b/main.go
@@ -115,10 +115,10 @@ func main() {
 
 	klogZap, err := zaputil.BuildForKlog(zflags.GetConfig(), flag.CommandLine)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to build zap logger for klog: %v", err))
+		setupLog.Error(err, "Failed to build zap logger for klog, those logs will not go through zap")
+	} else {
+		klog.SetLogger(zapr.NewLogger(klogZap).WithName("klog"))
 	}
-
-	klog.SetLogger(zapr.NewLogger(klogZap).WithName("klog"))
 
 	printVersion()
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,9 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/go-logr/zapr"
 	"github.com/spf13/pflag"
+	"github.com/stolostron/go-log-utils/zaputil"
 	policiesv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -27,11 +29,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/lease"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	iampolicyv1 "github.com/stolostron/iam-policy-controller/api/v1"
 	"github.com/stolostron/iam-policy-controller/controllers"
@@ -57,8 +59,14 @@ func printVersion() {
 }
 
 func main() {
-	opts := zap.Options{}
-	opts.BindFlags(flag.CommandLine)
+	zflags := zaputil.FlagConfig{
+		LevelName:   "log-level",
+		EncoderName: "log-encoder",
+	}
+
+	zflags.Bind(flag.CommandLine)
+	klog.InitFlags(flag.CommandLine)
+
 	// Add flags registered by imported packages (e.g. glog and controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
@@ -98,7 +106,19 @@ func main() {
 
 	pflag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrlZap, err := zflags.BuildForCtrl()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build zap logger for controller: %v", err))
+	}
+
+	ctrl.SetLogger(zapr.NewLogger(ctrlZap))
+
+	klogZap, err := zaputil.BuildForKlog(zflags.GetConfig(), flag.CommandLine)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build zap logger for klog: %v", err))
+	}
+
+	klog.SetLogger(zapr.NewLogger(klogZap).WithName("klog"))
 
 	printVersion()
 

--- a/main.go
+++ b/main.go
@@ -62,11 +62,10 @@ func main() {
 	// Add flags registered by imported packages (e.g. glog and controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
-	var clusterName, namespace, eventOnParent, hubConfigSecretNs, hubConfigSecretName, metricsAddr, probeAddr string
+	var clusterName, eventOnParent, hubConfigSecretNs, hubConfigSecretName, metricsAddr, probeAddr string
 	var frequency uint
 	var enableLease, enableLeaderElection, legacyLeaderElection bool
 
-	pflag.StringVar(&namespace, "watch-ns", "default", "Watched Kubernetes namespace")
 	pflag.UintVar(&frequency, "update-frequency", 10, "The status update frequency (in seconds) of a mutation policy")
 	pflag.StringVar(
 		&eventOnParent,


### PR DESCRIPTION
Our logs will be configurable through `--log-level`, klog level (used by controller-runtime, for example) will be configurable through `--v`.

This also fixes a small bug where the `--watch-ns` flag could not be used. It is just removed, since it doesn't seem to be necessary.