### PR TITLE
Add `policy-type=template` label to CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,9 @@ KUSTOMIZE = $(LOCAL_BIN)/kustomize
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 .PHONY: manifests
-manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=iam-policy-controller paths="./..." output:crd:artifacts:config=deploy/crds output:rbac:artifacts:config=deploy/rbac
+manifests: controller-gen kustomize
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=iam-policy-controller paths="./..." output:crd:artifacts:config=deploy/crds/kustomize output:rbac:artifacts:config=deploy/rbac
+	$(KUSTOMIZE) build deploy/crds/kustomize > deploy/crds/policy.open-cluster-management.io_iampolicies.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/deploy/crds/kustomize/kustomization.yaml
+++ b/deploy/crds/kustomize/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - policy.open-cluster-management.io_iampolicies.yaml
+
+# Use patches to add field validation that Kubebuilder markers can't
+patches:
+  - path: patches.json
+    target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: iampolicies.policy.open-cluster-management.io

--- a/deploy/crds/kustomize/patches.json
+++ b/deploy/crds/kustomize/patches.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add",
+    "path": "/metadata/labels",
+    "value": { "policy.open-cluster-management.io/policy-type": "template" }
+  }
+]

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_iampolicies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_iampolicies.yaml
@@ -1,11 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
-  labels:
-    policy.open-cluster-management.io/policy-type: template
   name: iampolicies.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io


### PR DESCRIPTION
This label is used to identify kinds that controllers should be monitoring for orphaned object cleanup.

ref: https://issues.redhat.com/browse/ACM-3049