### PR TITLE
Fix hosted mode in iam controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
       ```
   - Deploy controller to a cluster
 
-    The controller is deployed to a namespace defined in `CONTROLLER_NAMESPACE` and monitors the namepace defined in `WATCH_NAMESPACE` for `IamPolicy` resources.
+    The controller is deployed to a namespace defined in `KIND_NAMESPACE` and monitors the namepace defined in `WATCH_NAMESPACE` for `IamPolicy` resources.
 
     1. Create the deployment namespaces
        ```bash
@@ -75,7 +75,7 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
        ```
        The deployment namespaces are configurable with:
        ```bash
-       export CONTROLLER_NAMESPACE=''  # (defaults to 'open-cluster-management-agent-addon')
+       export KIND_NAMESPACE=''  # (defaults to 'open-cluster-management-agent-addon')
        export WATCH_NAMESPACE=''       # (defaults to 'managed')
        ```
     2. Deploy the controller and related resources


### PR DESCRIPTION
reusable GitHub workflow for running the Kind E2E tests in hosted mode was added. We need to now trigger these tests from the component repos as part of the PR CI in releases 2.7+.

Modify the governance-policy-framework release-2.7, release-2.8, and main branches to consolidate this as a new job in the existing reusable workflow file.

Ref: https://issues.redhat.com/browse/ACM-5211