### PR TITLE
[release-2.10] Use entitled Dockerfile for Konflux

### DIFF
--- a/.tekton/iam-policy-controller-acm-210-pull-request.yaml
+++ b/.tekton/iam-policy-controller-acm-210-pull-request.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
     - name: dockerfile
-      value: build/Dockerfile
+      value: build/Dockerfile.rhtap
     - name: git-url
       value: '{{source_url}}'
     - name: image-expires-after

--- a/.tekton/iam-policy-controller-acm-210-push.yaml
+++ b/.tekton/iam-policy-controller-acm-210-push.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   params:
     - name: dockerfile
-      value: build/Dockerfile
+      value: build/Dockerfile.rhtap
     - name: git-url
       value: '{{source_url}}'
     - name: output-image

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,12 +1,13 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: Use image builder to build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.21-linux AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21 AS builder
 
 ENV COMPONENT=iam-policy-controller
 ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}
 WORKDIR ${REPO_PATH}
 COPY . .
+RUN go mod vendor
 RUN make build
 
 # Stage 2: Copy the binaries from the image builder to the base image


### PR DESCRIPTION
Also updates ubi8 --> ubi9

ref: https://issues.redhat.com/browse/ACM-10739